### PR TITLE
Async entity select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-context-form-select",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/AsyncEntitySelect/AsyncEntitySelect.tsx
+++ b/src/AsyncEntitySelect/AsyncEntitySelect.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import * as PropTypes from "prop-types";
+
+import {Async, Option} from "react-select";
+
+export interface AsyncEntitySelectProps {
+    loadOptions: () => Promise<Array<{label: string, value: any}>>;
+    minLength?: number;
+}
+
+export const AsyncEntitySelectPropTypes = {
+    loadOptions: PropTypes.func.isRequired,
+    minLength: PropTypes.number,
+};
+
+export const AsyncEntitySelectDefaultProps = {
+    minLength: 3,
+};
+
+export interface AsyncEntitySelectState {
+    cache: { [T: string]: Option[] };
+}
+
+export class AsyncEntitySelect
+    extends React.Component<AsyncEntitySelectProps, AsyncEntitySelectState> {
+
+    public static readonly propTypes = AsyncEntitySelectPropTypes;
+    public static readonly defaultProps = AsyncEntitySelectDefaultProps;
+
+    public state: AsyncEntitySelectState = {
+        cache: {
+            "": []
+        }
+    };
+
+    public render() {
+        const {loadOptions, ...props} = this.props;
+
+        return (
+            <Async
+                {...props}
+                loadOptions={this.loadOptions}
+                cache={this.state.cache}
+            />
+        );
+    }
+
+    protected loadOptions = async (value: string): Promise<{ options: Option[] }> => {
+        if (value.length < this.props.minLength) {
+            return {options: []};
+        }
+
+        const options = await this.props.loadOptions();
+
+        this.state.cache[""] = [...this.state.cache[""], ...options];
+        this.forceUpdate();
+
+        return {options};
+    }
+}

--- a/src/AsyncEntitySelect/index.ts
+++ b/src/AsyncEntitySelect/index.ts
@@ -1,0 +1,1 @@
+export * from "./AsyncEntitySelect";


### PR DESCRIPTION
Create async entity select that will store all loaded options in cache and call loadOptions() only when min value`s length is reached